### PR TITLE
Enable ProcessTreeKiller in cpython engine

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.1.4
+version=0.1.5

--- a/src/main/java/jsr223/cpython/PythonScriptEngine.java
+++ b/src/main/java/jsr223/cpython/PythonScriptEngine.java
@@ -42,6 +42,8 @@ import javax.script.SimpleBindings;
 
 import org.apache.log4j.Logger;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
+import org.ow2.proactive.scheduler.task.SchedulerVars;
+import org.ow2.proactive.utils.CookieBasedProcessTreeKiller;
 
 import jsr223.cpython.entrypoint.EntryPoint;
 import jsr223.cpython.processbuilder.SingletonPythonProcessBuilderFactory;
@@ -117,11 +119,28 @@ public class PythonScriptEngine extends AbstractScriptEngine {
                                                                             .getProcessBuilder(pythonCommand);
 
         Process process = null;
+        Thread shutdownHook = null;
+        CookieBasedProcessTreeKiller processTreeKiller = null;
 
         try {
 
+            processTreeKiller = createProcessTreeKiller(context, processBuilder.environment());
+
             //Start process
             process = processBuilder.start();
+
+            final Process shutdownHookProcessReference = process;
+            final CookieBasedProcessTreeKiller shutdownHookPTKReference = processTreeKiller;
+            shutdownHook = new Thread() {
+                @Override
+                public void run() {
+                    destroyProcessAndWaitForItToBeDestroyed(shutdownHookProcessReference);
+                    if (shutdownHookPTKReference != null) {
+                        shutdownHookPTKReference.kill();
+                    }
+                }
+            };
+            Runtime.getRuntime().addShutdownHook(shutdownHook);
 
             //Attach streams
             processBuilderUtilities.attachStreamsToProcess(process,
@@ -168,8 +187,42 @@ public class PythonScriptEngine extends AbstractScriptEngine {
             }
             //Stop the gateway server
             gatewayServer.shutdown();
+
+            if (shutdownHook != null) {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            }
+
+            if (processTreeKiller != null) {
+                processTreeKiller.kill();
+            }
         }
         return null;
+    }
+
+    private static void destroyProcessAndWaitForItToBeDestroyed(Process process) {
+        try {
+            process.destroy();
+            process.waitFor();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private CookieBasedProcessTreeKiller createProcessTreeKiller(ScriptContext context,
+            Map<String, String> environment) {
+        CookieBasedProcessTreeKiller processTreeKiller = null;
+        Map<String, String> genericInfo = (Map<String, String>) context.getBindings(ScriptContext.ENGINE_SCOPE)
+                                                                       .get(SchedulerConstants.GENERIC_INFO_BINDING_NAME);
+        Map<String, String> variables = (Map<String, String>) context.getBindings(ScriptContext.ENGINE_SCOPE)
+                                                                     .get(SchedulerConstants.VARIABLES_BINDING_NAME);
+
+        if (genericInfo != null && variables != null &&
+            !"true".equalsIgnoreCase(genericInfo.get(SchedulerConstants.DISABLE_PROCESS_TREE_KILLER_GENERIC_INFO))) {
+            String cookieSuffix = "CPython_Job" + variables.get(SchedulerVars.PA_JOB_ID) + "Task" +
+                                  variables.get(SchedulerVars.PA_TASK_ID);
+            processTreeKiller = CookieBasedProcessTreeKiller.createProcessChildrenKiller(cookieSuffix, environment);
+        }
+        return processTreeKiller;
     }
 
     @Override


### PR DESCRIPTION
 - a cookie is generated based on job and task ids if available
 - process tree killer is run after the script execution or in case of abort
 - use shutdown hook also to handle fork mode